### PR TITLE
Improves ST. rank() algorithm

### DIFF
--- a/src/main/java/com/tables/ST.java
+++ b/src/main/java/com/tables/ST.java
@@ -25,7 +25,6 @@ public class ST<Key extends Comparable<Key>, Value> {
 	
 	/**
 	 * creates a new symbol table object
-	 * @param capacity size of the symbol table as int.
 	 */
 	@SuppressWarnings("unchecked")
 	public ST() {
@@ -111,7 +110,7 @@ public class ST<Key extends Comparable<Key>, Value> {
 	
 	
 	/**
-	 * retreives the value corresponding to a given key
+	 * retrieves the value corresponding to a given key
 	 * in the symbol table.
 	 * @param key
 	 * @return
@@ -187,13 +186,19 @@ public class ST<Key extends Comparable<Key>, Value> {
 			int mid = lo + (hi- lo) / 2;
 			int cmp = key.compareTo(keys[mid]);
 			
-			if (cmp > 0) {
+			if (cmp == 0)
+			   return mid;
+			else if (cmp > 0) {
 				lo = mid + 1;
 			}
 			else if (cmp < 0) {
 				hi = mid - 1;
 			}
-		}		
+		}
+		if (lo == 0)
+		   return lo;
+		if (key.compareTo(keys[lo]) > 0)   
+		   return lo + 1;
 		return lo;
 	}
 	


### PR DESCRIPTION
Changed the ST.rank() algorithm to avoid infinite loops and incorrect return values. rank() should now always return the proper index for its key parameter. Also removed an old @param tag.
